### PR TITLE
Abstract parameters class

### DIFF
--- a/tests/uws/uws_models_test.py
+++ b/tests/uws/uws_models_test.py
@@ -289,12 +289,10 @@ class TestParametersElement(TestCase):
     def test_validate(self):
         """Test validation against XML schema"""
 
-        parameters = Parameters(
-            parameter=[
-                Parameter(id="param1", value="value1"),
-                Parameter(id="param2", value="value2"),
-                Parameter(id="param3", value="value3"),
-            ]
+        parameters = self.TestParameters(
+            param1=Parameter(id="param1", value="value1"),
+            param2=Parameter(id="param2", value="value2"),
+            param3=Parameter(id="param3", value="value3"),
         )
         parameters_xml = etree.fromstring(parameters.to_xml(skip_empty=True, encoding=str))
         uws_schema.assertValid(parameters_xml)

--- a/vo_models/xml/uws/models.py
+++ b/vo_models/xml/uws/models.py
@@ -4,8 +4,8 @@ from typing import Dict, Generic, Optional, TypeVar
 from pydantic import field_validator
 from pydantic_xml import BaseXmlModel, attr, element
 
-from vo_models.xml.voresource.types import UTCTimestamp
 from vo_models.xml.uws.types import ErrorType, ExecutionPhase, UWSVersion
+from vo_models.xml.voresource.types import UTCTimestamp
 from vo_models.xml.xlink import XlinkType
 
 NSMAP = {
@@ -54,13 +54,7 @@ class Parameter(BaseXmlModel, tag="parameter", ns="uws", nsmap=NSMAP):
 
 
 class Parameters(BaseXmlModel, tag="parameters", ns="uws", nsmap=NSMAP):
-    """A list of UWS Job parameters.
-
-    Elements:
-    parameter (Parameter): a UWS Job parameter.
-    """
-
-    parameter: Optional[list[Parameter]] = element(name="parameter", default_factory=list)
+    """An abstract holder of UWS parameters."""
 
 
 class ErrorSummary(BaseXmlModel, tag="errorSummary", ns="uws", nsmap=NSMAP):

--- a/vo_models/xml/uws/models.py
+++ b/vo_models/xml/uws/models.py
@@ -56,6 +56,19 @@ class Parameter(BaseXmlModel, tag="parameter", ns="uws", nsmap=NSMAP):
 class Parameters(BaseXmlModel, tag="parameters", ns="uws", nsmap=NSMAP):
     """An abstract holder of UWS parameters."""
 
+    def __init__(__pydantic_self__, **data) -> None:  # pylint: disable=no-self-argument
+        # during init -- especially if reading from xml -- we may not get the parameters in the order
+        # pydantic-xml expects. This will remap the dict with keys based on the parameter id.
+        parameter_vals = [val for val in data.values() if val is not None]
+        remapped_vals = {}
+        for param in parameter_vals:
+            if isinstance(param, dict):
+                remapped_vals[param["id"]] = Parameter(**param)
+            else:
+                remapped_vals[param.id] = param
+        data = remapped_vals
+        super().__init__(**data)
+
 
 class ErrorSummary(BaseXmlModel, tag="errorSummary", ns="uws", nsmap=NSMAP):
     """A short summary of an error - a fuller representation of the


### PR DESCRIPTION
Makes the Parameters UWS model an abstract class that can be inherited from to create more rigidly validated models.

Changes interaction behavior from a list of Parameter() objects to named attributes of the Parameters class.