### PR TITLE
v0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vo-models"
-version = "0.2.1"
+version = "0.2.2.dev"
 authors = [
     {name = "Joshua Fraustro", email="jfraustro@stsci.edu"},
     {name = "MAST Archive Developers", email="archive@stsci.edu"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vo-models"
-version = "0.2.2.dev"
+version = "0.2.2"
 authors = [
     {name = "Joshua Fraustro", email="jfraustro@stsci.edu"},
     {name = "MAST Archive Developers", email="archive@stsci.edu"}

--- a/vo_models/vosi/availability/models.py
+++ b/vo_models/vosi/availability/models.py
@@ -13,7 +13,7 @@ NSMAP = {
 }
 
 
-class Availability(BaseXmlModel, tag="availability", nsmap=NSMAP):
+class Availability(BaseXmlModel, tag="availability", nsmap=NSMAP, skip_empty=True):
     """VOSI Availability complex type.
 
     Elements:
@@ -26,7 +26,7 @@ class Availability(BaseXmlModel, tag="availability", nsmap=NSMAP):
     """
 
     available: bool = element(tag="available")
-    up_since: Optional[UTCTimestamp] = element(tag="upSince")
-    down_at: Optional[UTCTimestamp] = element(tag="downAt")
-    back_at: Optional[UTCTimestamp] = element(tag="backAt")
-    note: Optional[list[str]] = element(tag="note")
+    up_since: Optional[UTCTimestamp] = element(tag="upSince", default=None)
+    down_at: Optional[UTCTimestamp] = element(tag="downAt", default=None)
+    back_at: Optional[UTCTimestamp] = element(tag="backAt", default=None)
+    note: Optional[list[str]] = element(tag="note", default=None)


### PR DESCRIPTION
* moves Parameters documentation to the correct class
* updates the Parameter class's value type hint to be any primitive - iterables, others, wouldn't be valid anyway.
* bug fix for VOSIAvailability to set its Optional values to None correctly - a requirement for Pydantic v2