### PR TITLE
Add py.typed file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ docs = ["sphinx", "sphinx_design", "furo", "sphinx-copybutton", "toml", "sphinx_
 Homepage = "https://github.com/spacetelescope/vo-models"
 Issues = "https://github.com/spacetelescope/vo-models/issues"
 
+[tool.setuptools.package-data]
+"vo_models" = ["py.typed"]
+
 [tool.ruff]
 line-length = 120
 extend-exclude = ["docs/conf.py"]


### PR DESCRIPTION
PEP 561 standardized the presence of a py.typed file at the top level of a module as an indication the module has usable type annotations. Since this module does provide type annotations, it should include this file to tell type checkers such as mypy to use those annotations.

See [the typing documentation](https://typing.readthedocs.io/en/latest/spec/distributing.html#packaging-typed-libraries) for more information.

Since there wasn't a `[build-system]` table in `pyproject.toml`, I assumed setuptools and added the configuration for it. Let me know if you're using a different build system and want configuration for it instead.