### PR TITLE
Update deprecated Pydantic constructions

### DIFF
--- a/tests/uws/uws_models_test.py
+++ b/tests/uws/uws_models_test.py
@@ -271,7 +271,7 @@ class TestParametersElement(TestCase):
         """Test reading from XML"""
 
         parameters = self.TestParameters.from_xml(self.test_parameters_xml)
-        self.assertEqual(len(parameters.dict()), 3)
+        self.assertEqual(len(parameters.model_dump()), 3)
 
         self.assertEqual(parameters.param1.id, "param1")
         self.assertEqual(parameters.param2.id, "param2")
@@ -360,7 +360,7 @@ class TestJobSummaryElement(TestCase):
         )
         self.assertEqual(job_summary.execution_duration, 0)
         self.assertEqual(job_summary.destruction, UTCTimestamp(1900, 1, 1, 1, 1, 1, tzinfo=tz.utc))
-        self.assertEqual(len(job_summary.parameters.dict()), 2)
+        self.assertEqual(len(job_summary.parameters.model_dump()), 2)
         self.assertEqual(job_summary.parameters.param1.id, "param1")
         self.assertEqual(job_summary.parameters.param2.id, "param2")
         self.assertEqual(job_summary.parameters.param1.value, "value1")

--- a/vo_models/uws/models.py
+++ b/vo_models/uws/models.py
@@ -1,6 +1,7 @@
 """UWS Job Schema using Pydantic-XML models"""
 from typing import Dict, Generic, Optional, TypeVar
 
+from pydantic import ConfigDict
 from pydantic_xml import BaseXmlModel, attr, element
 
 from vo_models.uws.types import ErrorType, ExecutionPhase, UWSVersion
@@ -238,10 +239,7 @@ class JobSummary(BaseXmlModel, Generic[ParametersType], tag="job", ns="uws", nsm
 
     version: Optional[UWSVersion] = attr(default=UWSVersion.V1_1)
 
-    class Config:
-        """JobSummary pydantic config options"""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class Job(JobSummary, tag="job"):


### PR DESCRIPTION
vo-models depends on Pydantic 2.x or later, so the older syntax compatible with Pydantic 1.x can be safely removed. Convert from class-based configuration to the new model_config class variable and change two tests to use the `model_dump` method instead of the deprecated `dict` method.

This clears all of the Python warning output from running `pytest`.