### PR TITLE
ASB-29242: Update reserved ADQL/SQL keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vo-models"
-version = "0.4.2"
+version = "0.4.2.dev0"
 authors = [
     {name = "Joshua Fraustro", email="jfraustro@stsci.edu"},
     {name = "MAST Archive Developers", email="archive@stsci.edu"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vo-models"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     {name = "Joshua Fraustro", email="jfraustro@stsci.edu"},
     {name = "MAST Archive Developers", email="archive@stsci.edu"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vo-models"
-version = "0.4.2.dev0"
+version = "0.4.2"
 authors = [
     {name = "Joshua Fraustro", email="jfraustro@stsci.edu"},
     {name = "MAST Archive Developers", email="archive@stsci.edu"}

--- a/tests/vodataservice/vodataservice_models_test.py
+++ b/tests/vodataservice/vodataservice_models_test.py
@@ -164,6 +164,24 @@ class TestTableParam(TestCase):
             canonicalize(self.test_xml, strip_text=True),
         )
 
+    def test_reserved_adql_words(self):
+        """Test that reserved ADQL/SQL words are properly escaped in column names"""
+
+        non_reserved = TableParam(column_name="aperture")
+        reserved_no_quotes = TableParam(column_name="distance")
+        reserved_single_quotes = TableParam(column_name="'offset'")
+        reserved_mixed_quotes = TableParam(column_name='"\'top\'"')
+
+        self.assertEqual(non_reserved.column_name, "aperture")
+        self.assertEqual(reserved_no_quotes.column_name, '"distance"')
+        self.assertEqual(reserved_single_quotes.column_name, '"offset"')
+        self.assertEqual(reserved_mixed_quotes.column_name, '"top"')
+
+        self.assertIn("<name>aperture</name>", non_reserved.to_xml(encoding=str))
+        self.assertIn("<name>\"distance\"</name>", reserved_no_quotes.to_xml(encoding=str))
+        self.assertIn("<name>\"offset\"</name>", reserved_single_quotes.to_xml(encoding=str))
+        self.assertIn("<name>\"top\"</name>", reserved_mixed_quotes.to_xml(encoding=str))
+
 
 class TestTableElement(TestCase):
     """Test the Table element model"""

--- a/vo_models/adql/misc.py
+++ b/vo_models/adql/misc.py
@@ -32,8 +32,8 @@ ADQL_SQL_KEYWORDS = [
     "CATALOG",
     "CHAR",
     "CHARACTER",
-    "CHARACTER_LENGTH",
     "CHAR_LENGTH",
+    "CHARACTER_LENGTH",
     "CHECK",
     "CLOSE",
     "COALESCE",
@@ -238,6 +238,7 @@ ADQL_SQL_KEYWORDS = [
     "ATAN2",
     "CEILING",
     "COS",
+    "COT",
     "DEGREES",
     "EXP",
     "FLOOR",
@@ -252,7 +253,6 @@ ADQL_SQL_KEYWORDS = [
     "SIN",
     "SQRT",
     "TAN",
-    "TOP",
     "TRUNCATE",
     # ADQL geometry keywords
     "AREA",
@@ -268,4 +268,13 @@ ADQL_SQL_KEYWORDS = [
     "POINT",
     "POLYGON",
     "REGION",
+    # Cast functions and datatypes
+    "BIGINT",
+    # String functions and operators
+    "ILIKE",
+    # Conversion functions
+    "IN_UNIT",
+    # Cardinality
+    "OFFSET",
+    "TOP",
 ]

--- a/vo_models/vodataservice/models.py
+++ b/vo_models/vodataservice/models.py
@@ -176,7 +176,8 @@ class TableParam(BaseXmlModel, ns="", tag="column"):
 
         value: - The column name to escape.
         """
-        if value.upper() in ADQL_SQL_KEYWORDS:
+        if value.strip("'\"").upper() in ADQL_SQL_KEYWORDS:
+            value = value.strip("'\"")
             value = f'"{value}"'
         return value
 


### PR DESCRIPTION
Updates the list of reserved ADQL/SQL keywords to include values from ADQL2.1, which are tested for by taplint.

Also makes the TableParam validator a little more robust by checking for incorrectly quoted column names.