### PR TITLE
ASB-31493: Namespace fixes for pydantic-xml 2.16.0

### DIFF
--- a/examples/snippets/uws/uws.py
+++ b/examples/snippets/uws/uws.py
@@ -203,7 +203,6 @@ job_summary.to_xml()
 job_summary_xml = """
 <uws:job xmlns:uws="http://www.ivoa.net/xml/UWS/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     version="1.1">
     <uws:jobId>job_1</uws:jobId>

--- a/examples/snippets/vosi/availability.py
+++ b/examples/snippets/vosi/availability.py
@@ -16,7 +16,6 @@ availability.to_xml()
 avail_xml = """
 <availability
     xmlns="http://www.ivoa.net/xml/VOSIAvailability/v1.0"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <available>true</available>
 <upSince>2023-01-01T00:00:00.000Z</upSince>

--- a/tests/uws/uws_models_test.py
+++ b/tests/uws/uws_models_test.py
@@ -24,7 +24,6 @@ from vo_models.voresource.types import UTCTimestamp
 
 UWS_NAMESPACE_HEADER = """xmlns:uws="http://www.ivoa.net/xml/UWS/v1.0"
 xmlns:xlink="http://www.w3.org/1999/xlink"
-xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 """
 

--- a/tests/vodataservice/VODataService-v1.2.xsd
+++ b/tests/vodataservice/VODataService-v1.2.xsd
@@ -1,0 +1,978 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0"
+    xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1"
+    xmlns:stc="http://www.ivoa.net/xml/STC/stc-v1.30.xsd"
+    xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1"
+    targetNamespace="http://www.ivoa.net/xml/VODataService/v1.1" elementFormDefault="unqualified"
+    attributeFormDefault="unqualified" version="1.2">
+    <xs:annotation>
+        <xs:appinfo>
+            <vm:schemaName>VODataService</vm:schemaName>
+<vm:schemaPrefix>xs</vm:schemaPrefix>
+<vm:targetPrefix>
+            vs</vm:targetPrefix>
+        </xs:appinfo>
+        <xs:documentation> An extension to the core resource metadata (VOResource) for describing
+            data collections and services. </xs:documentation>
+    </xs:annotation>
+    <xs:import namespace="http://www.ivoa.net/xml/VOResource/v1.0"
+        schemaLocation="http://www.ivoa.net/xml/VOResource/v1.0" />
+    <xs:import namespace="http://www.ivoa.net/xml/STC/stc-v1.30.xsd"
+        schemaLocation="http://www.ivoa.net/xml/STC/stc-v1.30.xsd" />
+    <xs:complexType name="DataCollection">
+        <xs:annotation>
+            <xs:documentation> A logical grouping of data which, in general, is composed of one or
+                more accessible datasets. A collection can contain any combination of images,
+                spectra, catalogues, or other data. </xs:documentation>
+            <xs:documentation> (A dataset is a collection of digitally-encoded data that is normally
+                accessible as a single unit, e.g., a file.) </xs:documentation>
+            <xs:documentation> This type is deprecated. Resource record authors should use
+                vs:CatalogResource instead. This type will be removed from the schema when no
+                resource record using it remains in the registry. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vr:Resource">
+                <xs:sequence>
+                    <xs:element name="facility" type="vr:ResourceName" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:appinfo>
+                                <vm:dcterm>Subject</vm:dcterm>
+                            </xs:appinfo>
+                            <xs:documentation> the observatory or facility used to collect the data
+                                contained or managed by this resource. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="instrument" type="vr:ResourceName" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:appinfo>
+                                <vm:dcterm>Subject</vm:dcterm>
+<vm:dcterm>Subject.Instrument</vm:dcterm>
+                            </xs:appinfo>
+                            <xs:documentation> the Instrument used to collect the data contain or
+                                managed by a resource. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="rights" type="vr:Rights" minOccurs="0" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:appinfo>
+                                <vm:dcterm>Rights</vm:dcterm>
+                            </xs:appinfo>
+                            <xs:documentation> Information about rights held in and over the
+                                resource. </xs:documentation>
+                            <xs:documentation> This should be repeated for all Rights values that
+                                apply. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="format" type="vs:Format" minOccurs="0" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation> The physical or digital manifestation of the
+                                information supported by a resource. </xs:documentation>
+                            <xs:documentation> This should use RFC 2046 media (“MIME”) types for
+                                network-retrievable, digital data. Non-RFC 2046 values could be used
+                                for media that cannot be retrieved over the network. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="coverage" type="vs:Coverage" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> Extent of the content of the resource over space,
+                                time, and frequency. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="tableset" type="vs:TableSet" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> A description of the tables that are part of this
+                                collection. </xs:documentation>
+                            <xs:documentation> Each schema name must be unique within a tableset. </xs:documentation>
+                        </xs:annotation>
+                        <xs:unique name="DataCollection-schemaName">
+                            <xs:selector xpath="schema" />
+                            <xs:field xpath="name" />
+                        </xs:unique>
+                    </xs:element>
+                    <xs:element name="accessURL" type="vr:AccessURL" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> The URL that can be used to download the data
+                                contained in this data collection. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="SpatialCoverage">
+        <xs:annotation>
+            <xs:documentation> A coverage on a sphere. By default, this refers to the celestial
+                sphere in the ICRS frame. Non-celestial frames are indicated by non-NULL values of
+                the frame attribute. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute name="frame" type="xs:token">
+                    <xs:annotation>
+                        <xs:documentation> When present, the MOC is written in a non-celestial
+                            (e.g., planetary) frame. Note that for celestial coverages, ICRS must be
+                            used. </xs:documentation>
+                        <xs:documentation> VODataService 1.2 does not prescribe a vocabulary for
+                            what values are allowed here. As long as no such vocabulary is agreed
+                            upon, the frame attribute should not be set. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="Coverage">
+        <xs:annotation>
+            <xs:documentation> A description of how a resource's contents or behavior maps to the
+                sky, to time, and to frequency space, including coverage and resolution. </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="stc:STCResourceProfile" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> An STC 1.0 description of the location of the resource's data
+                        on the sky, in time, and in frequency space, including resolution. This is
+                        deprecated in favour of the separate spatial, temporal, and spectral
+                        elements. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="spatial" type="vs:SpatialCoverage" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> An ASCII-serialized MOC defining the spatial coverage of the
+                        resource. </xs:documentation>
+                    <xs:documentation> The MOC is to be understood in the ICRS reference frame
+                        unless a frame attribute is given. Resources should give the coverage at
+                        least to order 6 (a resolution of about one degree). The order should be
+                        chosen so as to keep the resulting MOC smaller than a few dozens of kB. If
+                        desired, a more precise MOC can be provided on a dedicated endpoint declared
+                        in the footprint element. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="temporal" type="vs:FloatInterval" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A pair of lower, upper limits of a time interval for which
+                        the resource offers data. </xs:documentation>
+                    <xs:documentation> This is written as for VOTable tabledata (i.e.,
+                        whitespace-separated C-style floating point literals), as in “47847.2
+                        51370.2”. The limits must be given as MJD. While they are not intended to be
+                        precise, they are to be understood in TDB for the solar system barycenter.
+                        The total coverage of the resource is the union of all such intervals. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="spectral" type="vs:FloatInterval" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A pair of lower, upper limits of a spectral interval for
+                        which the resource offers data. </xs:documentation>
+                    <xs:documentation> This is written as for VOTable tabledata (i.e.,
+                        whitespace-separated C-style floating point literals). The limits must be
+                        given in Joules of particle energies. While the limits are not intended to
+                        be precise, they are to be understood for the solar system barycenter. </xs:documentation>
+                    <xs:documentation> For instance, the Johnson V waveband (480 .. 730 nm) would be
+                        specified as “2.72e-19 4.14e-19” </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="footprint" type="vs:ServiceReference" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A reference to a footprint service for retrieving precise and
+                        up-to-date description of coverage. </xs:documentation>
+                    <xs:documentation> The ivo-id attribute here refers to the standard in which the
+                        footprint is given. The only value defined by VODataService at this point is
+                        ivo://ivoa.net/std/moc, which indicates that retrieving the footprint URL
+                        will return a MOC (any IVOA-approved serialisation is legal). Note that the
+                        ivo-id attribute was intended to have a different function in VODataService
+                        1.1. The current meaning is what implementors actually adopted. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="waveband" type="xs:token" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <vm:dcterm>Coverage.Spectral</vm:dcterm>
+                    </xs:appinfo>
+                    <xs:documentation> A name of a messenger that the resource is relevant for
+                        (e.g., was used in the measurements). Terms must be taken from the
+                        vocabulary at http://www.ivoa.net/rdf/messenger. </xs:documentation>
+                    <xs:documentation> It is a bit unfortunate that the element is still called
+                        waveband when it is now also covers non-electromagnetic messengers. It was
+                        deemed that this slight notional sloppiness is preferable to introducing new
+                        and deprecating old elements. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="regionOfRegard" type="xs:float" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <vm:dcterm>Coverage.RegionOfRegard</vm:dcterm>
+                    </xs:appinfo>
+                    <xs:documentation> A single numeric value representing the angle, given in
+                        decimal degrees, by which a positional query against this resource should be
+                        “blurred” in order to get an appropriate match. </xs:documentation>
+                    <xs:documentation> In the case of image repositories, it might refer to a
+                        typical field-of-view size, or the primary beam size for radio aperture
+                        synthesis data. In the case of object catalogues RoR should normally be the
+                        largest of the typical size of the objects, the astrometric errors in the
+                        positions, or the resolution of the data. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ServiceReference">
+        <xs:annotation>
+            <xs:documentation> The service URL for a potentially registered service. That is, if an
+                IVOA identifier is also provided, then the service is described in a registry. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:anyURI">
+                <xs:attribute name="ivo-id" type="vr:IdentifierURI">
+                    <xs:annotation>
+                        <xs:documentation> The URI form of the IVOA identifier for the service
+                            describing the capability refered to by this element. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="TableSet">
+        <xs:annotation>
+            <xs:documentation> The set of tables hosted by a resource. </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="schema" type="vs:TableSchema" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A named description of a group of logically related tables. </xs:documentation>
+                    <xs:documentation> The name given by the “name” child element must be unique
+                        within this TableSet instance. If there is only one schema in this set
+                        and/or there is no locally appropriate name to provide, the name can be set
+                        to “default”. </xs:documentation>
+                    <xs:documentation> This aggregation does not need to map to an actual database,
+                        catalogue, or schema, though the publisher may choose to aggregate along
+                        such designations. Particular service protocols may require stricter
+                        patterns. </xs:documentation>
+                </xs:annotation>
+                <xs:unique name="DataCollection-tableName">
+                    <xs:selector xpath="table" />
+                    <xs:field xpath="name" />
+                </xs:unique>
+            </xs:element>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" />
+    </xs:complexType>
+    <xs:complexType name="TableSchema">
+        <xs:annotation>
+            <xs:documentation> A detailed description of a logically related group of tables. </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:token" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation> A name for the group of tables. </xs:documentation>
+                    <xs:documentation> This is used to uniquely identify the group of tables among
+                        several groups. If no title is given, this name can be used for display
+                        purposes. </xs:documentation>
+                    <xs:documentation> If there is no appropriate logical name associated with this
+                        group, the name should be explicitly set to “default”. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="title" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A descriptive, human-interpretable name for the group of
+                        tables. </xs:documentation>
+                    <xs:documentation> This is used for display purposes. There is no requirement
+                        regarding uniqueness. It is useful when there are multiple schemas in the
+                        context (e.g., within a tableset; otherwise, the resource title could be
+                        used instead). </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A free text description of the group of tables that should
+                        explain in general how all of the tables in the group are related. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="utype" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> An identifier for a concept in a data model that the data in
+                        this schema as a whole represent. </xs:documentation>
+                    <xs:documentation> The form of the utype string depends on the data model;
+                        common forms are sequences of dotted identifiers (e.g., in SSA) or URIs
+                        (e.g., in RegTAP). </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="table" type="vs:Table" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A description of one table. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" />
+    </xs:complexType>
+    <xs:complexType name="Format">
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute name="isMIMEType" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation> If true, the content of the element is an RFC
+                            2046-compliant media time. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="DataResource">
+        <xs:annotation>
+            <xs:documentation> A resource publishing astronomical data. </xs:documentation>
+            <xs:documentation> This resource type should only be used if the resource has no common
+                underlying tabular schema (e.g., an inhomogeneous archive). Use CatalogResource
+                otherwise. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vr:Service">
+                <xs:sequence>
+                    <xs:element name="facility" type="vr:ResourceName" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:appinfo>
+                                <vm:dcterm>Subject</vm:dcterm>
+                            </xs:appinfo>
+                            <xs:documentation> The observatory or facility used to collect the data
+                                contained or managed by this resource. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="instrument" type="vr:ResourceName" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:appinfo>
+                                <vm:dcterm>Subject</vm:dcterm>
+<vm:dcterm>Subject.Instrument</vm:dcterm>
+                            </xs:appinfo>
+                            <xs:documentation> The instrument used to collect the data contain or
+                                managed by a resource. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="coverage" type="vs:Coverage" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> Extent of the content of the resource over space,
+                                time, and frequency. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="DataService">
+        <xs:annotation>
+            <xs:documentation> A service for accessing astronomical data. </xs:documentation>
+            <xs:documentation> This resource type should only be used if the service has no common
+                underlying tabular schema (e.g., a storage service) or if it is not explicitly
+                accessible (e.g., an ftp server with images). Use CatalogService otherwise. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vs:DataResource" />
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ParamHTTP">
+        <xs:annotation>
+            <xs:documentation> A service invoked via an HTTP Query (either Get or Post) with a set
+                of arguments consisting of keyword name-value pairs. </xs:documentation>
+            <xs:documentation> Note that the URL for help with this service can be put into the
+                service/referenceURL element. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vr:Interface">
+                <xs:sequence>
+                    <xs:element name="queryType" type="vs:HTTPQueryType" minOccurs="0" maxOccurs="2">
+                        <xs:annotation>
+                            <xs:documentation> The type of HTTP request, either GET or POST. </xs:documentation>
+                            <xs:documentation> The service may indicate support for both GET and
+                                POST by providing 2 queryType elements, one with GET and one with
+                                POST. Since the IVOA standard DALI requires standard services to
+                                support both GET and POST, this piece of metadata is not useful in
+                                the description of standard DAL services and does not need to be
+                                given for those. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="resultType" type="xs:token" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> The MIME media type of a document returned in the
+                                HTTP response. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="param" type="vs:InputParam" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation> A description of a input parameter that can be
+                                provided as a name=value argument to the service. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="testQuery" type="xs:string" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> An ampersand-delimited list of arguments that can be
+                                used to test this service interface; when provided as the input to
+                                this interface, it will produce a legal, non-null response. </xs:documentation>
+                            <xs:documentation> When the interface supports GET, then the full query
+                                URL is formed by the concatenation of the base URL (given by the
+                                accessURL) and the value given by this testQuery element. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:simpleType name="HTTPQueryType">
+        <xs:annotation>
+            <xs:documentation> The type of HTTP request, either GET or POST. </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="GET" />
+            <xs:enumeration value="POST" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="CatalogResource">
+        <xs:annotation>
+            <xs:documentation> A resource giving astronomical data in tabular form. </xs:documentation>
+            <xs:documentation> While this includes classical astronomical catalogues, this resource
+                is also appropriate for collections of observations or simulation results provided
+                their metadata are available in a sufficiently structured form (e.g., Obscore, SSAP,
+                etc). </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vs:DataResource">
+                <xs:sequence>
+                    <xs:element name="tableset" type="vs:TableSet" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> A description of the tables that are accessible
+                                through this service. </xs:documentation>
+                            <xs:documentation> Each schema name must be unique within a tableset. </xs:documentation>
+                        </xs:annotation>
+                        <xs:unique name="CatalogService-schemaName">
+                            <xs:selector xpath="schema" />
+                            <xs:field xpath="name" />
+                        </xs:unique>
+                        <xs:unique name="CatalogService-tableName">
+                            <xs:selector xpath="schema/table" />
+                            <xs:field xpath="name" />
+                        </xs:unique>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="CatalogService">
+        <xs:annotation>
+            <xs:documentation> A service that interacts with astronomical data through one or more
+                specified tables. </xs:documentation>
+            <xs:documentation> This is the appropriate resource type for normal VO services, e.g.,
+                TAP, SSAP, SIAP, ConeSearch. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vs:CatalogResource" />
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="Table">
+        <xs:sequence>
+            <xs:element name="name" type="xs:token" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation> The fully qualified name of the table. This name should
+                        include all catalogue or schema prefixes needed to sufficiently uniquely
+                        distinguish it in a query. </xs:documentation>
+                    <xs:documentation> In general, the format of the qualified name may depend on
+                        the context; however, when the table is intended to be queryable via ADQL,
+                        then the catalogue and schema qualifiers are delimited from the table name
+                        with dots (.). </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="title" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A descriptive, human-interpretable name for the table. </xs:documentation>
+                    <xs:documentation> This is used for display purposes. There is no requirement
+                        regarding uniqueness. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A free-text description of the table's contents </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="utype" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> An identifier for a concept in a data model that the data in
+                        this table represent. </xs:documentation>
+                    <xs:documentation> The form of the utype string depends on the data model;
+                        common forms are sequences of dotted identifiers (e.g., in SSA) or URIs
+                        (e.g., in RegTAP). </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="nrows" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> The approximate size of the table in rows. </xs:documentation>
+                    <xs:documentation> This is not expected to be exact. For instance, the estimates
+                        on table sizes databases keep for query planning purposes are suitable for
+                        this field. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="column" type="vs:TableParam" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A description of a table column. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="foreignKey" type="vs:ForeignKey" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A description of a foreign keys, one or more columns from the
+                        current table that can be used to join with another table. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string">
+            <xs:annotation>
+                <xs:documentation> A name for the role this table plays. Recognized values include
+                    “output”, indicating this table is output from a query; “base_table”, indicating
+                    a table whose records represent the main subjects of its schema; and “view”,
+                    indicating that the table represents a useful combination or subset of other
+                    tables. Other values are allowed. </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" />
+    </xs:complexType>
+    <xs:complexType name="BaseParam">
+        <xs:annotation>
+            <xs:documentation> A description of a parameter that places no restriction on the
+                parameter's data type. </xs:documentation>
+            <xs:documentation> As the parameter's data type is usually important, schemas normally
+                employ a sub-class of this type rather than this type directly. </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> The name of the parameter or column. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A free-text description of a parameter's or column's
+                        contents. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="unit" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> The unit associated with the values in the parameter or
+                        column. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ucd" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> The name of a unified content descriptor that describes the
+                        scientific content of the parameter. </xs:documentation>
+                    <xs:documentation> There are no requirements for compliance with any particular
+                        UCD standard. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="utype" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> An identifier for a concept in a data model that the data in
+                        this schema represent. </xs:documentation>
+                    <xs:documentation> The form of the utype string depends on the data model;
+                        common forms are sequences of dotted identifiers (e.g., in SSA) or URIs
+                        (e.g., in RegTAP). </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" />
+    </xs:complexType>
+    <xs:complexType name="TableParam">
+        <xs:annotation>
+            <xs:documentation> A description of a table parameter having a fixed data type. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vs:BaseParam">
+                <xs:sequence>
+                    <xs:element name="dataType" type="vs:TableDataType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> A type of data contained in the column </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="flag" type="xs:token" minOccurs="0" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation> A keyword representing traits of the column.
+                                Recognized values include “indexed”, “primary”, and “nullable”. </xs:documentation>
+                            <xs:documentation> While other values are allowed, the following
+                                semantics is defined by this specification: indexed – The column has
+                                an index on it for faster search against its values; primary – The
+                                values column in the column represent in total or in part a primary
+                                key for its table; nullable – the column may contain null or empty
+                                values. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="std" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation> If true, the meaning and use of this parameter is
+                            reserved and defined by a standard model. If false, it represents a
+                            parameter specific to the data described If not provided, then the value
+                            is unknown. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="InputParam">
+        <xs:annotation>
+            <xs:documentation> A description of a service or function parameter having a fixed data
+                type. </xs:documentation>
+            <xs:documentation> DALI-compliant services should use VOTableType here, others should
+                use SimpleDataType. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vs:BaseParam">
+                <xs:sequence>
+                    <xs:element name="dataType" type="vs:DataType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation> A type of data contained in the parameter. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="use" type="vs:ParamUse" default="optional">
+                    <xs:annotation>
+                        <xs:documentation> An indication of whether this parameter is required to be
+                            provided for the application or service to work properly. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="std" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation> If true, the meaning and behavior of this parameter is
+                            reserved and defined by a standard interface. If false, it represents an
+                            implementation-specific parameter that effectively extends the behavior
+                            of the service or application. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:simpleType name="ParamUse">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="required">
+                <xs:annotation>
+                    <xs:documentation> The parameter is required for the application or service to
+                        work properly. </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="optional">
+                <xs:annotation>
+                    <xs:documentation> The parameter is optional but supported by the application or
+                        service. </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ignored">
+                <xs:annotation>
+                    <xs:documentation> The parameter is not supported and thus is ignored by the
+                        application or service. </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="DataType">
+        <xs:annotation>
+            <xs:documentation> A type (in the computer language sense) associated with a parameter
+                with an arbitrary name </xs:documentation>
+            <xs:documentation> This XML type is used as a parent for defining data types with a
+                restricted set of names. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute name="arraysize" type="vs:ArrayShape">
+                    <xs:annotation>
+                        <xs:documentation> The shape of the array that constitutes the value. </xs:documentation>
+                        <xs:documentation> Leave arraysize empty for scalar values. In version 1.1,
+                            this defaulted to 1, which was intended to indicate a scalar. This is
+                            now deprecated; an arraysize of 1 should be avoided now, the future
+                            interpretation, in accord with VOTable, will be “array of size 1”. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delim" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation> A string that is used to delimit elements of an array
+                            value in InputParams. </xs:documentation>
+                        <xs:documentation> Unless specifically disallowed by the context,
+                            applications should allow optional spaces to appear in an actual data
+                            value before and after the delimiter (e.g., “1, 5” when delim=“,”). </xs:documentation>
+                        <xs:documentation> This should not be used for VOTable types; there, VOTable
+                            (typcially TABLEDATA) conventions for writing arrays are binding. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="extendedType" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation> The data value represented by this type can be
+                            interpreted as of a custom type identified by the value of this
+                            attribute. </xs:documentation>
+                        <xs:documentation> If an application does not recognize this extendedType,
+                            it should attempt to handle the value assuming the type given by the
+                            element's value. string is a recommended default type. </xs:documentation>
+                        <xs:documentation> This element may make use of the extendedSchema attribute
+                            to refine the identification of the type. extendedTypes without an
+                            extendedSchema mean VOTable xtypes as defined by DALI. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="extendedSchema" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation> An identifier for the schema that the value given by the
+                            extended attribute is drawn from. </xs:documentation>
+                        <xs:documentation> This attribute is normally ignored if the extendedType
+                            attribute is not present. A missing extendedSchema indicates that
+                            extendedType is a VOTable xtype. </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:anyAttribute namespace="##other" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <!--
+     -  this definition is taken from the VOTable arrayDEF type
+      -->
+    <xs:simpleType name="ArrayShape">
+        <xs:annotation>
+            <xs:documentation> An expression of a the shape of a multi-dimensional array of the form
+                LxNxM... where each value between gives the integer length of the array along a
+                dimension. An asterisk (*) as the last dimension of the shape indicates that the
+                length of the last axis is variable or undetermined. </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:pattern value="([0-9]+x)*[0-9]*[0-9*]" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="SimpleDataType">
+        <xs:annotation>
+            <xs:documentation> A data type restricted to a small set of names which is imprecise as
+                to the format of the individual values. </xs:documentation>
+            <xs:documentation> This set is intended for describing simple input parameters to a
+                service or function. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:restriction base="vs:DataType">
+                <xs:enumeration value="integer" />
+                <xs:enumeration value="real" />
+                <xs:enumeration value="complex" />
+                <xs:enumeration value="boolean" />
+                <xs:enumeration value="char" />
+                <xs:enumeration value="string" />
+                <xs:attribute name="arraysize" type="vs:ArrayShape">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delim" type="xs:string" default=" ">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="extendedType" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="extendedSchema" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:anyAttribute namespace="##other" />
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="TableDataType" abstract="true">
+        <xs:annotation>
+            <xs:documentation> An abstract parent for a class of data types that can be used to
+                specify the data type of a table column. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="vs:DataType" />
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="VOTableType">
+        <xs:annotation>
+            <xs:documentation> A data type supported explicitly by the VOTable format </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:restriction base="vs:TableDataType">
+                <xs:enumeration value="boolean" />
+                <xs:enumeration value="bit" />
+                <xs:enumeration value="unsignedByte" />
+                <xs:enumeration value="short" />
+                <xs:enumeration value="int" />
+                <xs:enumeration value="long" />
+                <xs:enumeration value="char" />
+                <xs:enumeration value="unicodeChar" />
+                <xs:enumeration value="float" />
+                <xs:enumeration value="double" />
+                <xs:enumeration value="floatComplex" />
+                <xs:enumeration value="doubleComplex" />
+                <xs:attribute name="arraysize" type="vs:ArrayShape">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delim" type="xs:string" default=" ">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="extendedType" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="extendedSchema" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>See vs:DataType.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:anyAttribute namespace="##other" />
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="TAPDataType" abstract="true">
+        <xs:annotation>
+            <xs:documentation> An abstract parent for the specific data types supported by the Table
+                Access Protocol. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="vs:TableDataType">
+                <xs:attribute name="size" type="xs:positiveInteger">
+                    <xs:annotation>
+                        <xs:documentation> The length of the fixed-length value </xs:documentation>
+                        <xs:documentation> This corresponds to the size Column attribute in the
+                            TAP_SCHEMA and can be used with data types that are defined with a
+                            length (CHAR, BINARY). </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="TAPType">
+        <xs:annotation>
+            <xs:documentation> A data type supported explicitly by the Table Access Protocol (v1.0).
+                This is deprecated in VODataService 1.2, and even TAP 1.0 services are encouraged to
+                declare their columns using VOTableType. </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:restriction base="vs:TAPDataType">
+                <xs:enumeration value="BOOLEAN" />
+                <xs:enumeration value="SMALLINT" />
+                <xs:enumeration value="INTEGER" />
+                <xs:enumeration value="BIGINT" />
+                <xs:enumeration value="REAL" />
+                <xs:enumeration value="DOUBLE" />
+                <xs:enumeration value="TIMESTAMP" />
+                <xs:enumeration value="CHAR" />
+                <xs:enumeration value="VARCHAR" />
+                <xs:enumeration value="BINARY" />
+                <xs:enumeration value="VARBINARY" />
+                <xs:enumeration value="POINT" />
+                <xs:enumeration value="REGION" />
+                <xs:enumeration value="CLOB" />
+                <xs:enumeration value="BLOB" />
+                <xs:attribute name="arraysize" type="vs:ArrayShape" />
+                <xs:attribute name="delim" type="xs:string" default=" " />
+                <xs:attribute name="extendedType" type="xs:string" />
+                <xs:attribute name="extendedSchema" type="xs:anyURI" />
+                <xs:attribute name="size" type="xs:positiveInteger" />
+                <xs:anyAttribute namespace="##other" />
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="StandardSTC">
+        <xs:annotation>
+            <xs:documentation> A description of standard space-time coordinate systems, positions,
+                and regions. </xs:documentation>
+            <xs:documentation> This resource type is deprecated, and no resource records of this
+                type exist in the Registry. It will be removed in version 1.3 of VODataService. </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="vr:Resource">
+                <xs:sequence>
+                    <xs:element name="stcDefinitions" type="stc:stcDescriptionType" minOccurs="1"
+                        maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation> An STC description of coordinate systems, positions,
+                                and/or regions </xs:documentation>
+                            <xs:documentation> Each system, position, and region description should
+                                have a an XML ID assigned to it. </xs:documentation>
+                            <xs:documentation> Because the STC schema sets
+                                elementFormDefault="qualified", it is recommended that this element
+                                specify the STC default namespace via an xmlns namespace. </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ForeignKey">
+        <xs:annotation>
+            <xs:documentation> A description of the mapping a foreign key -- a set of columns from
+                one table -- to columns in another table. </xs:documentation>
+            <xs:documentation> When foreign keys are declared in this way, clients can expect that
+                joins constrained with the foreign keys are preformed efficiently (e.g., using an
+                index). </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="targetTable" type="xs:token">
+                <xs:annotation>
+                    <xs:documentation> The fully qualified name (including catalogue and schema, as
+                        applicable) of the table that can be joined with the table containing this
+                        foreign key. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="fkColumn" type="vs:FKColumn" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation> A pair of column names, one from this table and one from the
+                        target table that should be used to join the tables in a query. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> A free-text description of what this key points to and what
+                        the relationship means. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="utype" type="xs:token" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation> An identifier for a concept in a data model that the
+                        association enabled by this key represents. </xs:documentation>
+                    <xs:documentation> The form of the utype string depends on the data model;
+                        common forms are sequences of dotted identifiers (e.g., in SSA) or URIs
+                        (e.g., in RegTAP). </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="FKColumn">
+        <xs:annotation>
+            <xs:documentation> A pair of columns that are used to join two tables. </xs:documentation>
+            <xs:documentation> To do an inner join of data from the two tables, a query should
+                include a constraint that sets the value from the first column equal to the value in
+                the second column. </xs:documentation>
+            <xs:documentation> This type assumes that it is used in the context of implied source
+                (i.e., current) and target tables, as in the ForeignKey type's fkColumn. </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="fromColumn" type="xs:token">
+                <xs:annotation>
+                    <xs:documentation> The unqualified name of the column from the current table. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="targetColumn" type="xs:token">
+                <xs:annotation>
+                    <xs:documentation> The unqualified name of the column from the target table. </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="FloatInterval">
+        <xs:annotation>
+            <xs:documentation> An interval of floating point numbers. </xs:documentation>
+            <xs:documentation> This uses VOTable TABLEDATA serialisation, i.e., simply a pair of XSD
+                floating point numbers separated by whitespace; note that software utilising non-XSD
+                aware parsers has to perform whitespace normalisation itself here (in particular,
+                for the internal whitespace). </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:pattern
+                value="[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)? [+-]?([0-9]+\.?[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)?" />
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/tests/voresource/voresource_models_test.py
+++ b/tests/voresource/voresource_models_test.py
@@ -31,8 +31,6 @@ from vo_models.voresource.types import UTCDateTime, UTCTimestamp, ValidationLeve
 
 VORESOURCE_NAMESPACE_HEADER = """
     xmlns:xml="http://www.w3.org/XML/1998/namespace",
-    xmlns="http://www.w3.org/2001/XMLSchema",
-    xmlns:xs="http://www.w3.org/2001/XMLSchema",
     xmlns="http://www.ivoa.net/xml/VOResource/v1.0",
     xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1",
 """

--- a/tests/vosi/availability_test.py
+++ b/tests/vosi/availability_test.py
@@ -13,7 +13,6 @@ from vo_models.voresource.types import UTCTimestamp
 from vo_models.vosi.availability import Availability
 
 VOSI_AVAILABILITY_HEADER = """xmlns="http://www.ivoa.net/xml/VOSIAvailability/v1.0"
-xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 """
 

--- a/tests/vosi/capabilities_test.py
+++ b/tests/vosi/capabilities_test.py
@@ -238,6 +238,7 @@ class TestVOSICapabilities(TestCase):
 
     def test_write_to_xml(self):
         """Test writing VOSI Capabilities to XML."""
+
         test_xml = self.test_vosi_capabilities_model.to_xml(encoding=str, skip_empty=True)
         self.assertEqual(
             canonicalize(test_xml, strip_text=True),

--- a/vo_models/tapregext/models.py
+++ b/vo_models/tapregext/models.py
@@ -8,7 +8,6 @@ from vo_models.voresource.models import NSMAP as VORESOURCE_NSMAP
 from vo_models.voresource.models import Capability
 
 NSMAP = {
-    "xs": "http://www.w3.org/2001/XMLSchema",
     "vm": "http://www.ivoa.net/xml/VOMetadata/v0.1",
     "tr": "http://www.ivoa.net/xml/TAPRegExt/v1.0",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",

--- a/vo_models/uws/models.py
+++ b/vo_models/uws/models.py
@@ -11,7 +11,6 @@ from vo_models.xlink import XlinkType
 NSMAP = {
     "uws": "http://www.ivoa.net/xml/UWS/v1.0",
     "xlink": "http://www.w3.org/1999/xlink",
-    "xsd": "http://www.w3.org/2001/XMLSchema",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",
 }
 

--- a/vo_models/vodataservice/models.py
+++ b/vo_models/vodataservice/models.py
@@ -3,6 +3,7 @@
 TODO: This is an incomplete spec, covering only elements needed for VOSITables
 https://github.com/spacetelescope/vo-models/issues/17
 """
+
 from typing import Any, Literal, Optional
 from xml.sax.saxutils import escape
 
@@ -16,7 +17,6 @@ from vo_models.voresource.models import Interface
 
 NSMAP = {
     "": "http://www.ivoa.net/xml/VODataService/v1.1",
-    "xs": "http://www.w3.org/2001/XMLSchema",
     "vr": "http://www.ivoa.net/xml/VOResource/v1.0",
     "vs": "http://www.ivoa.net/xml/VODataService/v1.1",
     "stc": "http://www.ivoa.net/xml/STC/stc-v1.30.xsd",

--- a/vo_models/vodataservice/models.py
+++ b/vo_models/vodataservice/models.py
@@ -99,7 +99,7 @@ class DataType(BaseXmlModel, tag="dataType", nsmap={"xsi": "http://www.w3.org/20
     value: str
 
 
-class TableParam(BaseXmlModel, ns="", tag="column"):
+class TableParam(BaseXmlModel, tag="column"):
     """A description of a table column.
 
     Parameters:
@@ -189,7 +189,7 @@ class TableParam(BaseXmlModel, ns="", tag="column"):
         return value
 
 
-class Table(BaseXmlModel, tag="table", ns="", skip_empty=True):
+class Table(BaseXmlModel, tag="table", ns="", nsmap={"": ""}, skip_empty=True):
     """A model representing a single table element.
 
     Parameters:
@@ -223,12 +223,12 @@ class Table(BaseXmlModel, tag="table", ns="", skip_empty=True):
     table_type: Optional[str] = attr(name="type", default=None)
 
     table_name: str = element(tag="name", ns="")
-    title: Optional[str] = element(tag="title", ns="", default=None)
-    description: Optional[str] = element(tag="description", ns="", default=None)
-    utype: Optional[str] = element(tag="utype", ns="", default=None)
-    nrows: Optional[int] = element(tag="nrows", gte=0, ns="", default=None)
-    column: Optional[list[TableParam]] = element(tag="column", ns="", default_factory=list)
-    foreign_key: Optional[list[ForeignKey]] = element(tag="foreignKey", ns="", default_factory=list)
+    title: Optional[str] = element(tag="title", default=None, ns="")
+    description: Optional[str] = element(tag="description", default=None, ns="")
+    utype: Optional[str] = element(tag="utype", default=None, ns="")
+    nrows: Optional[int] = element(tag="nrows", gte=0, default=None, ns="")
+    column: Optional[list[TableParam]] = element(tag="column", default_factory=list, ns="")
+    foreign_key: Optional[list[ForeignKey]] = element(tag="foreignKey", default_factory=list, ns="")
 
     def __init__(__pydantic_self__, **data: Any) -> None:
         """Escape any keys that are passed in."""
@@ -246,7 +246,7 @@ class Table(BaseXmlModel, tag="table", ns="", skip_empty=True):
         return value
 
 
-class TableSchema(BaseXmlModel, tag="schema", ns="", skip_empty=True):
+class TableSchema(BaseXmlModel, tag="schema", ns="", nsmap={"": ""}, skip_empty=True):
     """A detailed description of a logically related group of tables.
 
     Parameters:

--- a/vo_models/voresource/models.py
+++ b/vo_models/voresource/models.py
@@ -1,4 +1,5 @@
 """Pydantic-xml models for IVOA schema VOResource-v1.1.xsd"""
+
 import datetime
 from typing import Literal, Optional
 
@@ -12,7 +13,6 @@ from vo_models.voresource.types import IdentifierURI, UTCTimestamp, ValidationLe
 
 NSMAP = {
     "vr": "http://www.ivoa.net/xml/VOResource/v1.0",
-    "xs": "http://www.w3.org/2001/XMLSchema",
     "vm": "http://www.ivoa.net/xml/VOMetadata/v0.1",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",
 }

--- a/vo_models/voresource/models.py
+++ b/vo_models/voresource/models.py
@@ -18,7 +18,7 @@ NSMAP = {
 }
 
 
-class Validation(BaseXmlModel, nsmap=NSMAP):
+class Validation(BaseXmlModel):
     """A validation stamp combining a validation level and the ID of the validator.
 
     Parameters:
@@ -41,7 +41,7 @@ class Validation(BaseXmlModel, nsmap=NSMAP):
         return values
 
 
-class ResourceName(BaseXmlModel, nsmap=NSMAP):
+class ResourceName(BaseXmlModel):
     """The name of a potentially registered resource.
 
     That is, the entity referred to may have an associated identifier.
@@ -57,7 +57,7 @@ class ResourceName(BaseXmlModel, nsmap=NSMAP):
     ivo_id: Optional[IdentifierURI] = attr(name="ivo-id", default=None)
 
 
-class Date(BaseXmlModel, nsmap=NSMAP):
+class Date(BaseXmlModel):
     """A string indicating what the date refers to.
 
     The value of role should be taken from the vocabulary maintained at http://www.ivoa.net/rdf/voresource/date_role.
@@ -75,7 +75,7 @@ class Date(BaseXmlModel, nsmap=NSMAP):
     )
 
 
-class Source(BaseXmlModel, nsmap=NSMAP):
+class Source(BaseXmlModel):
     """A bibliographic reference from which the present resource is derived or extracted.
 
     Parameters:
@@ -90,7 +90,7 @@ class Source(BaseXmlModel, nsmap=NSMAP):
     format: Optional[str] = attr(name="format", default=None)
 
 
-class Rights(BaseXmlModel, nsmap=NSMAP):
+class Rights(BaseXmlModel):
     """A statement of usage conditions.
 
     This will typically include a license, which should be given as a full string
@@ -107,7 +107,7 @@ class Rights(BaseXmlModel, nsmap=NSMAP):
     rights_uri: Optional[networks.AnyUrl] = attr(name="rightsURI", default=None)
 
 
-class AccessURL(BaseXmlModel, nsmap=NSMAP):
+class AccessURL(BaseXmlModel):
     """The URL (or base URL) that a client uses to access the service.
 
     Parameters:
@@ -122,7 +122,7 @@ class AccessURL(BaseXmlModel, nsmap=NSMAP):
     use: Literal["full", "base", "dir"] = attr(name="use")
 
 
-class MirrorURL(BaseXmlModel, nsmap=NSMAP):
+class MirrorURL(BaseXmlModel):
     """A URL of a mirror (i.e., a functionally identical additional service interface) to
 
     Parameters:
@@ -136,7 +136,7 @@ class MirrorURL(BaseXmlModel, nsmap=NSMAP):
     title: Optional[str] = attr(name="title", default=None)
 
 
-class Contact(BaseXmlModel, nsmap=NSMAP):
+class Contact(BaseXmlModel):
     """Information allowing establishing contact, e.g., for purposes of support.
 
     Parameters:
@@ -175,7 +175,7 @@ class Contact(BaseXmlModel, nsmap=NSMAP):
         return values
 
 
-class Creator(BaseXmlModel, nsmap=NSMAP):
+class Creator(BaseXmlModel):
     """The entity (e.g. person or organisation) primarily responsible for creating something
 
     Parameters:
@@ -208,7 +208,7 @@ class Creator(BaseXmlModel, nsmap=NSMAP):
         return values
 
 
-class Relationship(BaseXmlModel, nsmap=NSMAP):
+class Relationship(BaseXmlModel):
     """A description of the relationship between one resource and one or more other resources.
 
     Parameters:
@@ -225,7 +225,7 @@ class Relationship(BaseXmlModel, nsmap=NSMAP):
     related_resource: list[ResourceName] = element(tag="relatedResource")
 
 
-class SecurityMethod(BaseXmlModel, nsmap=NSMAP):
+class SecurityMethod(BaseXmlModel):
     """A description of a security mechanism.
 
     This type only allows one to refer to the mechanism via a URI.  Derived types would allow for more metadata.
@@ -238,7 +238,7 @@ class SecurityMethod(BaseXmlModel, nsmap=NSMAP):
     standard_id: Optional[networks.AnyUrl] = attr(name="standardID", default=None)
 
 
-class Curation(BaseXmlModel, nsmap=NSMAP):
+class Curation(BaseXmlModel):
     """Information regarding the general curation of a resource
 
     Parameters:
@@ -265,7 +265,7 @@ class Curation(BaseXmlModel, nsmap=NSMAP):
     contact: list[Contact] = element(tag="contact")
 
 
-class Content(BaseXmlModel, nsmap=NSMAP):
+class Content(BaseXmlModel):
     """Information regarding the general content of a resource
 
     Parameters:
@@ -299,7 +299,7 @@ class Content(BaseXmlModel, nsmap=NSMAP):
     relationship: Optional[list[Relationship]] = element(tag="relationship", default_factory=list)
 
 
-class Interface(BaseXmlModel, tag="interface", nsmap=NSMAP):
+class Interface(BaseXmlModel, tag="interface"):
     """A description of a service interface.
 
     Since this type is abstract, one must use an Interface subclass to describe an actual interface denoting
@@ -326,7 +326,7 @@ class Interface(BaseXmlModel, tag="interface", nsmap=NSMAP):
 
     version: Optional[str] = attr(name="version", default=None)
     role: Optional[str] = attr(name="role", default=None)
-    type: Optional[str] = attr(name="type", default=None, ns="xsi")
+    type: Optional[str] = attr(name="type", default=None, ns="xsi", nsmap={"xsi": "http://www.w3.org/2001/XMLSchema-instance"})
 
     access_url: list[AccessURL] = element(tag="accessURL")
     mirror_url: Optional[list[MirrorURL]] = element(tag="mirrorURL", default_factory=list)
@@ -334,13 +334,13 @@ class Interface(BaseXmlModel, tag="interface", nsmap=NSMAP):
     test_querystring: Optional[str] = element(tag="testQueryString", default=None)
 
 
-class WebBrowser(Interface, nsmap=NSMAP):
+class WebBrowser(Interface):
     """A (form-based) interface intended to be accesed interactively by a user via a web browser."""
 
     type: Literal["vr:WebBrowser"] = attr(name="type", default="vr:WebBrowser", ns="xsi")
 
 
-class WebService(Interface, nsmap=NSMAP):
+class WebService(Interface):
     """A Web Service that is describable by a WSDL document.
 
     The accessURL element gives the Web Service's endpoint URL.
@@ -350,12 +350,14 @@ class WebService(Interface, nsmap=NSMAP):
             (element) - The location of the WSDL that describes this Web Service.
     """
 
-    type: Literal["vr:WebService"] = attr(name="type", default="vr:WebService", ns="xsi")
+    type: Literal["vr:WebService"] = attr(
+        name="type", default="vr:WebService", ns="xsi", nsmap={"xsi": "http://www.w3.org/2001/XMLSchema-instance"}
+    )
 
     wsdl_url: Optional[list[networks.AnyUrl]] = element(tag="wsdlURL", default_factory=list)
 
 
-class Resource(BaseXmlModel, nsmap=NSMAP):
+class Resource(BaseXmlModel):
     """Any entity or component of a VO application that is describable and
                         identifiable by an IVOA Identifier.
 
@@ -415,7 +417,7 @@ class Resource(BaseXmlModel, nsmap=NSMAP):
         return values
 
 
-class Organisation(Resource, nsmap=NSMAP):
+class Organisation(Resource):
     """A named group of one or more persons brought together to pursue participation in VO applications.
 
     Parameters:
@@ -430,7 +432,7 @@ class Organisation(Resource, nsmap=NSMAP):
     instrument: Optional[list[ResourceName]] = element(tag="instrument", default_factory=list)
 
 
-class Capability(BaseXmlModel, tag="capability", nsmap=NSMAP):
+class Capability(BaseXmlModel, tag="capability"):
     """A description of what the service does (in terms of context-specific behavior), and how to use it
     (in terms of an interface)
 
@@ -458,7 +460,7 @@ class Capability(BaseXmlModel, tag="capability", nsmap=NSMAP):
     interface: Optional[list[Interface]] = element(tag="interface", default_factory=list)
 
 
-class Service(Resource, nsmap=NSMAP):
+class Service(Resource):
     """A resource that can be invoked by a client to perform some action on its behalf.
 
     Parameters:

--- a/vo_models/vosi/availability/models.py
+++ b/vo_models/vosi/availability/models.py
@@ -8,7 +8,6 @@ from vo_models.voresource.types import UTCTimestamp
 
 NSMAP = {
     "": "http://www.ivoa.net/xml/VOSIAvailability/v1.0",
-    "xsd": "http://www.w3.org/2001/XMLSchema",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",
 }
 

--- a/vo_models/vosi/capabilities/models.py
+++ b/vo_models/vosi/capabilities/models.py
@@ -10,7 +10,6 @@ from vo_models.voresource.models import Capability
 
 NSMAP = {
     "vosi": "http://www.ivoa.net/xml/VOSICapabilities/v1.0",
-    "xsd": "http://www.w3.org/2001/XMLSchema",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",
     "vs": "http://www.ivoa.net/xml/VODataService/v1.1",
 } | VORESOURCE_NSMAP

--- a/vo_models/vosi/capabilities/models.py
+++ b/vo_models/vosi/capabilities/models.py
@@ -28,5 +28,6 @@ class VOSICapabilities(BaseXmlModel, tag="capabilities", ns="vosi", nsmap=NSMAP)
     capability: list[Union[TableAccess, Capability]] = element(
         tag="capability",
         ns="",
+        nsmap={"": ""},
         default=[],
     )

--- a/vo_models/vosi/tables/models.py
+++ b/vo_models/vosi/tables/models.py
@@ -5,7 +5,6 @@ NSMAP = {
     "vosi": "http://www.ivoa.net/xml/VOSITables/v1.0",
     "vr": "http://www.ivoa.net/xml/VOResource/v1.0",
     "vs": "http://www.ivoa.net/xml/VODataService/v1.1",
-    "xsd": "http://www.w3.org/2001/XMLSchema",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",
 }
 


### PR DESCRIPTION
Changes to pydantic-xml in 2.16.0 means that exceptions are thrown if a namespace alias is not present in a namespace map. 

This PR implements changes that keep compatibility with both versions.